### PR TITLE
Separate Connections for Rabbit Send/Receive

### DIFF
--- a/cmd/plane.filter/main.go
+++ b/cmd/plane.filter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -61,7 +62,9 @@ func (r *rabbit) connect(timeout time.Duration) error {
 
 	log.Info().Str("host", rabbitConfig.String()).Msg("Connecting to RabbitMQ")
 	r.rmq = rabbitmq.New(&rabbitConfig)
-	return r.rmq.ConnectAndWait(timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return r.rmq.ConnectAndWait(ctx)
 }
 
 func (r *rabbit) makeQueue(name string) error {

--- a/cmd/pw_router/main.go
+++ b/cmd/pw_router/main.go
@@ -170,7 +170,9 @@ func runCli(c *cli.Context) error {
 func (r *pwRouter) connect(config rabbitmq.Config, timeout time.Duration) error {
 	log.Info().Str("host", config.String()).Msg("Connecting to RabbitMQ")
 	r.rmq = rabbitmq.New(&config)
-	return r.rmq.ConnectAndWait(timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return r.rmq.ConnectAndWait(ctx)
 }
 
 func (r *pwRouter) makeQueue(name, bindRouteKey string) error {

--- a/cmd/pw_ws_broker/rabbit.go
+++ b/cmd/pw_ws_broker/rabbit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"github.com/rs/zerolog/log"
@@ -31,7 +32,9 @@ func (br *PwWsBrokerRabbit) configureRabbitMq() error {
 	if nil == br.rabbit {
 		return errors.New("you need to configure the rabbit client")
 	}
-	if err := br.rabbit.ConnectAndWait(5 * time.Second); nil != err {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := br.rabbit.ConnectAndWait(ctx); nil != err {
 		return err
 	}
 

--- a/lib/rabbitmq/config.go
+++ b/lib/rabbitmq/config.go
@@ -1,0 +1,54 @@
+package rabbitmq
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+type (
+	ConfigSSL struct {
+		PrivateKeyFile string `json:"private_key_file"`
+		CertChainFile  string `json:"cert_chain_file"`
+	}
+
+	Config struct {
+		Host     string    `json:"host"`
+		Port     string    `json:"port"`
+		Vhost    string    `json:"vhost"`
+		User     string    `json:"user"`
+		Password string    `json:"password"`
+		Ssl      ConfigSSL `json:"ssl"`
+	}
+)
+
+func (cfg Config) String() string {
+	u := url.URL{
+		Scheme: "amqp",
+		Host:   net.JoinHostPort(cfg.Host, cfg.Port),
+		Path:   strings.TrimLeft(fmt.Sprintf("/%s", cfg.Vhost), "/"),
+		User:   url.UserPassword(cfg.User, cfg.Password),
+	}
+	return u.String()
+}
+
+func NewConfigFromUrl(connectUrl string) (*Config, error) {
+	rabbitUrl, err := url.Parse(connectUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	rabbitPassword, _ := rabbitUrl.User.Password()
+
+	rabbitConfig := Config{
+		Host:     rabbitUrl.Hostname(),
+		Port:     rabbitUrl.Port(),
+		User:     rabbitUrl.User.Username(),
+		Password: rabbitPassword,
+		Vhost:    rabbitUrl.Path,
+		Ssl:      ConfigSSL{},
+	}
+
+	return &rabbitConfig, nil
+}

--- a/lib/sink/rabbitmq.go
+++ b/lib/sink/rabbitmq.go
@@ -1,6 +1,7 @@
 package sink
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
@@ -319,7 +320,10 @@ func (r *RabbitMqSink) connect(timeout time.Duration) (*rabbitmq.RabbitMQ, error
 
 	log.Info().Str("host", rabbitConfig.String()).Msg("Connecting to RabbitMQ")
 	rabbit := rabbitmq.New(&rabbitConfig)
-	return rabbit, rabbit.ConnectAndWait(timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return rabbit, rabbit.ConnectAndWait(ctx)
 }
 
 func (r *RabbitMqSink) setup() error {


### PR DESCRIPTION
I found that we should be using separate connections for Send/Receive… (Consume/Publish) for RabbitMQ

Also took the chance to change over to using modern Context for specifying timeouts

Reorganised the rabbitmq lib a little too